### PR TITLE
feat: Add Maybe functor

### DIFF
--- a/.changeset/tasty-eels-rule.md
+++ b/.changeset/tasty-eels-rule.md
@@ -1,0 +1,5 @@
+---
+"@ortense/functors": minor
+---
+
+Add Maybe functor

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typescript",
     "type-safe",
     "monad",
-    "monads"
+    "monads",
+    "maybe"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/Maybe/Maybe.spec.ts
+++ b/src/Maybe/Maybe.spec.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vitest } from 'vitest'
+import { Maybe, maybe } from './Maybe'
+
+describe('Maybe', () => {
+  it('should be defined', () => {
+    expect(Maybe).toBeDefined()
+  })
+
+  describe('.create', () => {
+    it('should create a Maybe instance', () => {
+      const maybeStr = Maybe.create('val')
+      expect(maybeStr).toBeInstanceOf(Maybe)
+    })
+  })
+
+  describe('maybe function', () => {
+    it('should create a Maybe instance', () => {
+      const maybeStr = maybe('val')
+      expect(maybeStr).toBeInstanceOf(Maybe)
+    })
+  })
+
+  describe('Instance methods', () => {
+    describe('.map', () => {
+      it('should call mapper function with populated value', () => {
+        const value = ['value']
+        const maybeVal = Maybe.create(value)
+        const fn = vitest.fn()
+        maybeVal.map(fn)
+        expect(fn).toHaveBeenCalledWith(value)
+      })
+
+      it('should not call mapper function with empty value', () => {
+        const maybeEmpty = Maybe.create<string[]>(null)
+        const fn = vitest.fn()
+        maybeEmpty.map(fn)
+        expect(fn).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('.mapEmpty', () => {
+      it('should call mapper function when empty', () => {
+        const maybeEmpty = Maybe.create<string[]>(null)
+        const fn = vitest.fn()
+        maybeEmpty.mapEmpty(fn)
+        expect(fn).toHaveBeenCalled()
+      })
+
+      it('should not call mapper function when populated', () => {
+        const maybeVal = Maybe.create(['value'])
+        const fn = vitest.fn()
+        maybeVal.mapEmpty(fn)
+        expect(fn).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('.unwrap', () => {
+      it('should return wrapped value', () => {
+        const value = { foo: 'bar' }
+        const maybeVal = Maybe.create(value)
+        expect(maybeVal.unwrap()).toBe(value)
+      })
+    })
+  })
+})

--- a/src/Maybe/Maybe.ts
+++ b/src/Maybe/Maybe.ts
@@ -1,0 +1,91 @@
+/**
+ * Represents a container that may or may not contain a value of type T.
+ * @class Maybe
+ * @template T - The type of the value.
+ * @example Using maybe to check a environment variable
+ * ```
+ * const port = Maybe.create<string>(process.env.PORT)
+ *   .map(value => Number(value))
+ *   .map(value => Number.isNaN(value) ? 3000 : value)
+ *   .mapEmpty(() => 3000)
+ *   .unwrap()
+ * ```
+ */
+export class Maybe<T> {
+  /**
+   * Private constructor to create an instance of Maybe.
+   * @private
+   * @constructor
+   * @param {T | null | undefined} value - The value or absence of a value.
+   */
+  private constructor(private value: T | null | undefined) {}
+
+  /**
+   * Static method to create an instance of Maybe.
+   * @template T - The type of the value.
+   * @param {T | null | undefined} value - The value or absence of a value.
+   * @returns {Maybe<T>} An instance of Maybe.
+   */
+  static create<T>(value: T | null | undefined) {
+    return new Maybe(value)
+  }
+
+  /**
+   * Applies a function to the value inside the Maybe instance if it is present,
+   * returning a new Maybe instance containing the result of the function.
+   * If the Maybe instance is empty, it returns itself.
+   * @template R - The type of the result.
+   * @param {Function} fn - The function to apply to the value.
+   * @returns {Maybe<R>} A new Maybe instance containing the result of the function.
+   */
+  map<R>(fn: (value: T) => R): Maybe<R> {
+    if (this.value !== null && this.value !== undefined) {
+      return new Maybe<R>(fn(this.value))
+    }
+
+    return this as unknown as Maybe<R>
+  }
+
+  /**
+   * Applies a function to the value inside the Maybe instance if it is empty,
+   * returning a new Maybe instance containing the result of the function.
+   * If the Maybe instance is not empty, it returns itself.
+   * @template R - The type of the result.
+   * @param {Function} fn - The function to apply when the value is empty.
+   * @returns {Maybe<R>} A new Maybe instance containing the result of the function.
+   */
+  mapEmpty<R>(fn: () => R): Maybe<R> {
+    if (this.value === null || this.value === undefined) {
+      return new Maybe<R>(fn())
+    }
+
+    return this as unknown as Maybe<R>
+  }
+
+  /**
+   * Unwraps the value inside the Maybe instance.
+   * @returns {T | null | undefined} The value or absence of a value.
+   */
+  unwrap(): T | null | undefined {
+    return this.value
+  }
+}
+
+/**
+ * Creates a Maybe instance from a value, allowing safe and functional handling of potentially nullable or undefined values.
+ * @function maybe
+ * @template T - The type of the value.
+ * @param {T | undefined | null} value - The value to be wrapped in a Maybe instance.
+ * @returns {Maybe<T>} A Maybe instance representing the provided value.
+ * @example Using maybe to check if an environment variable is defined and convert it to a number
+ * ```
+ * const port = maybe(process.env.PORT)
+ *   .map(value => Number(value))
+ *   .map(value => Number.isNaN(value) ? 3000 : value)
+ *   .unwrap();
+ * ```
+ */
+
+export function maybe<T>(value: T | undefined | null): Maybe<T> {
+  return Maybe.create(value)
+}

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,8 +1,0 @@
-import {describe, it, expect } from 'vitest'
-import { add } from './index'
-
-describe('example', () => {
-  it('should pass', () => {
-    expect(add(1, 2)).toBe(3)
-  })
-})

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,1 @@
-export function add(x: number, y: number) {
-  return x + y
-}
+export * from './Maybe/Maybe'


### PR DESCRIPTION
# Description

Add Maybe functor.

## Usage example

Parsing an object from local storage

```typescript
import { maybe } from '@ortense/functors'

type Product = {
  id: string
  price: number
}

type Cart = {
  items: Product[]
}

const getTotalPrice = (): number => {
  return maybe<string>(localStorage.getItem('cart'))
    .map(json => JSON.parse(json) as Cart)
    .map(cart => cart.items)
    .map(products => products.reduce((acc, p) => acc + p.price, 0))
    .mapEmpty(() => 0)
    .unwrap()
}

const totalPrice = getTotalPrice()
console.log('Total Price:', totalPrice)
```

A WEB API made with Hono running on node.js to search users by ID in Deno KV

```ts
import { Hono } from 'hono'
import { serve } from '@hono/node-server'
import { openKv } from '@deno/kv'
import { Maybe } from '@ortense/functors'

type User = {
  id: string
  name: string
  email: string
}

const kv = await openKv('<KV Connect URL>')

async function getUser(id: string): Promise<Maybe<User>> {
  const res = await kv.get<User>(["users", id])
  return Maybe.create(res.value)
}

const app = new Hono()

app.get('/users/:id', async (ctx) => {
  const id = ctx.req.param('id')
  const result = await getUser(ctx.req.param('id'))

  return result
    .map(user => {
      ctx.status(200)
      return ctx.json(user)
    })
    .mapEmpty(() => {
      ctx.status(404)
      return ctx.json({ error: `user ${id} not found` })
    })
    .unwrap()
})

serve({
  fetch: app.fetch,
  port: 3000,
})
```