### PR TITLE
Feat: Either

### DIFF
--- a/.changeset/healthy-panthers-talk.md
+++ b/.changeset/healthy-panthers-talk.md
@@ -1,0 +1,5 @@
+---
+"@ortense/functors": minor
+---
+
+Add Either functor

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "maybe",
     "lazy",
     "history",
-    "state"
+    "state",
+    "either"
   ],
   "license": "MIT",
   "devDependencies": {

--- a/src/Either/Either.spec.ts
+++ b/src/Either/Either.spec.ts
@@ -1,0 +1,123 @@
+import { expect, describe, it, vi } from 'vitest'
+import { Either } from './Either'
+import { Left, left } from './Left'
+import { Right, right } from './Right'
+
+describe('Either', () => {
+  describe('Left', () => {
+    it('should be defined', () => {
+      expect(Left).toBeDefined()
+    })
+
+    describe('.create', () => {
+      it('should create a Left instance', () => {
+        const l = Left.create('val')
+        expect(l).toBeInstanceOf(Left)
+      })
+    })
+
+    describe('left function', () => {
+      it('should create a Left instance', () => {
+        const l = left('val')
+        expect(l).toBeInstanceOf(Left)
+      })
+    })
+
+    describe('Instance methods', () => {
+      describe('.left', () => {
+        it('should call mapper function', () => {
+          const mapper = vi.fn()
+          left('test').left(mapper)
+          expect(mapper).toHaveBeenCalledWith('test')
+        })
+      })
+
+      describe('.right', () => {
+        it('should not call mapper function', () => {
+          const mapper = vi.fn()
+          left('test').right(mapper)
+          expect(mapper).not.toHaveBeenCalled()
+        })
+      })
+
+      describe('.isLeft', () => {
+        it('should be true', () => {
+          expect(left('test').isLeft()).toBe(true)
+        })
+      })
+
+      describe('.isRight', () => {
+        it('should be false', () => {
+          expect(left('test').isRight()).toBe(false)
+        })
+      })
+
+      describe('.unwrap', () => {
+        it('should return wrapped value', () => {
+          const value = { foo: 'bar' }
+          const l = left(value)
+          expect(l.unwrap()).toBe(value)
+        })
+      })
+    })
+  })
+
+  describe('Right', () => {
+    it('should be defined', () => {
+      expect(Right).toBeDefined()
+    })
+
+    describe('.create', () => {
+      it('should create a Right instance', () => {
+        const r = Right.create('val')
+        expect(r).toBeInstanceOf(Right)
+      })
+    })
+
+    describe('right function', () => {
+      it('should create a Right instance', () => {
+        const r: Either<unknown, string> = right('val')
+        expect(r).toBeInstanceOf(Right)
+      })
+    })
+
+    describe('Instance methods', () => {
+      describe('.left', () => {
+        it('should not call mapper function', () => {
+          const mapper = vi.fn()
+          right('test').left(mapper)
+          expect(mapper).not.toHaveBeenCalledWith()
+        })
+      })
+
+      describe('.right', () => {
+        it('should not call mapper function', () => {
+          const mapper = vi.fn()
+          const l: Either<unknown, string>  = right('test')
+          l.right(mapper)
+          expect(mapper).toHaveBeenCalledWith('test')
+        })
+      })
+
+      describe('.isLeft', () => {
+        it('should be false', () => {
+          expect(right('test').isLeft()).toBe(false)
+        })
+      })
+
+      describe('.isRight', () => {
+        it('should be true', () => {
+          expect(right('test').isRight()).toBe(true)
+        })
+      })
+
+      describe('.unwrap', () => {
+        it('should return wrapped value', () => {
+          const value = { foo: 'bar' }
+          const r = right(value)
+          expect(r.unwrap()).toBe(value)
+        })
+      })
+    })
+  })
+})

--- a/src/Either/Either.ts
+++ b/src/Either/Either.ts
@@ -3,7 +3,57 @@
  * @interface Either
  * @template L The type of the left side.
  * @template R The type of the right side.
+ * @example Use Either to handle erros
+ * ```ts
+ * import { Either, left, right } from '@ortense/functors'
+ *
+ * const divide = (
+ *   numerator: number,
+ *   denominator: number,
+ * ): Either<Error, number> => {
+ *   if (Number.isNaN(numerator)) {
+ *     return left(new Error('Numerator is not a number.'))
+ *   }
+ *   if (Number.isNaN(denominator)) {
+ *     return left(new Error('Denominator is not a number.'))
+ *   }
+ *
+ *   if (denominator === 0) {
+ *     return left(new Error('Division by zero is not posible.'))
+ *   }
+ *
+ *   return right(numerator / denominator)
+ * }
+ * ```
+ * @example capture correct side value
+ * ```ts
+ * const numerator = Number(document.querySelector('input#numerator').value)
+ * const denominator = Number(document.querySelector('input#denominator').value)
+ * const display = document.querySelector('div#display-result')
+ * const onSuccess = (result: number) => {
+ *  display.textContent = `${numerator} / ${denominator} = ${result}`
+ * }
+ * const onError = (error: Error) => {
+ *   display.textContent = error.message
+ * }
+ *
+ * divide(numerator, denominator)
+ *   .right(onSuccess)
+ *   .left(onError)
+ * ```
+ * @example type-safe error handler
+ * ```ts
+ * app.post('/users', async (req, res) => {
+ *   const result: Either<Error, User> = await createUser(req.body)
+ *   result
+ *     .right(user => ({ id: user.id, name: user.name }))
+ *     .right(responseBody => res.status(201).json(responseBody))
+ *     .left(error => ({ error: error.name, message: error.message }))
+ *     .left(responseBody => res.status(400).json(responseBody))
+ * })
+ * ```
  */
+
 export interface Either<L, R> {
   /**
    * Applies a function to the value inside the Either instance **if it is on the left side**, returning a new Either instance containing the result of the function. If the Either is on the right side, it returns itself.

--- a/src/Either/Either.ts
+++ b/src/Either/Either.ts
@@ -1,0 +1,39 @@
+/**
+ * Represents a type that can be either of type L or R.
+ * @interface Either
+ * @template L The type of the left side.
+ * @template R The type of the right side.
+ */
+export interface Either<L, R> {
+  /**
+   * Applies a function to the value inside the Either instance **if it is on the left side**, returning a new Either instance containing the result of the function. If the Either is on the right side, it returns itself.
+   * @param {(value: L) => T} fn - A function to transform the value on the left side.
+   * @returns {Either} An Either instance representing the transformed left side.
+   */
+  left<T>(fn: (value: L) => T): Either<T, R>
+
+  /**
+   * Applies a function to the value inside the Either instance **if it is on the right side**, returning a new Either instance containing the result of the function. If the Either is on the left side, it returns itself.
+   * @param {(value: L) => T} fn - A function to transform the value on the right side.
+   * @returns {Either} An Either instance representing the transformed right side.
+   */
+  right<T>(fn: (value: R) => T): Either<L, T>
+
+  /**
+   * Checks if the Either instance is on the left side.
+   * @returns {boolean} True if the instance is on the left side, otherwise false.
+   */
+  isLeft(): boolean
+
+  /**
+   * Checks if the Either instance is on the right side.
+   * @returns {boolean} True if the instance is on the right side, otherwise false.
+   */
+  isRight(): boolean
+
+  /**
+   * Unwraps the value contained in the Either instance.
+   * @returns {L | R} The value contained in the Either instance.
+   */
+  unwrap(): L | R
+}

--- a/src/Either/Left.ts
+++ b/src/Either/Left.ts
@@ -1,0 +1,51 @@
+import { Either } from './Either.ts'
+
+/**
+ * Represents the left side of an Either type.
+ * @class Left
+ * @implements {Either}
+ * @template L - The type of the left side.
+ * @template R - The type of the right side.
+ */
+export class Left<L, R> implements Either<L, R> {
+  /**
+   * Private constructor to create an instance of `Left`.
+   * @private
+   * @constructor
+   * @param {L} val - The value on the left side.
+   */
+  private constructor(private val: L) {}
+
+  /**
+   * Static method to create an instance of Left.
+   * @param {L} value - The value on the left side.
+   * @returns {Left} An instance of Left.
+   */
+  static create<L, R>(value: L) {
+    return new Left<L, R>(value);
+  }
+
+  left<T>(fn: (value: L) => T): Either<T, R> {
+    return new Left<T, R>(fn(this.val));
+  }
+
+  right<T>(fn: (value: R) => T): Either<L, T> {
+    return this as unknown as Either<L, T>;
+  }
+
+  isLeft() {
+    return true;
+  }
+
+  isRight() {
+    return false;
+  }
+
+  unwrap() {
+    return this.val;
+  }
+}
+
+export function left<L, R>(value: L): Either<L, R> {
+  return Left.create<L, R>(value)
+}

--- a/src/Either/Left.ts
+++ b/src/Either/Left.ts
@@ -17,32 +17,34 @@ export class Left<L, R> implements Either<L, R> {
   private constructor(private val: L) {}
 
   /**
-   * Static method to create an instance of Left.
+   * Static method to create an instance of Right.
+   * @template L - The type of the left side.
+   * @template R - The type of the right side.
    * @param {L} value - The value on the left side.
-   * @returns {Left} An instance of Left.
+   * @returns {Either<L, R>} An instance of Left.
    */
-  static create<L, R>(value: L) {
-    return new Left<L, R>(value);
+  static create<L, R>(value: L): Either<L, R> {
+    return new Left<L, R>(value)
   }
 
   left<T>(fn: (value: L) => T): Either<T, R> {
-    return new Left<T, R>(fn(this.val));
+    return new Left<T, R>(fn(this.val))
   }
 
   right<T>(fn: (value: R) => T): Either<L, T> {
-    return this as unknown as Either<L, T>;
+    return this as unknown as Either<L, ReturnType<typeof fn>>
   }
 
   isLeft() {
-    return true;
+    return true
   }
 
   isRight() {
-    return false;
+    return false
   }
 
   unwrap() {
-    return this.val;
+    return this.val
   }
 }
 

--- a/src/Either/Right.ts
+++ b/src/Either/Right.ts
@@ -1,4 +1,4 @@
-import { Either } from './Either';
+import { Either } from './Either'
 
 /**
  * Represents the right side of an Either type.
@@ -18,31 +18,33 @@ export class Right<L, R> implements Either<L, R> {
 
   /**
    * Static method to create an instance of Right.
+   * @template L - The type of the left side.
+   * @template R - The type of the right side.
    * @param {R} value - The value on the right side.
-   * @returns {Right} An instance of Right.
+   * @returns {Either<L, R>} An instance of Right.
    */
-  static create<L, R>(value: R) {
-    return new Right<L, R>(value);
+  static create<L, R>(value: R): Either<L, R>  {
+    return new Right<L, R>(value)
   }
 
   left<T>(fn: (value: L) => T): Either<T, R> {
-    return this as unknown as Either<T, R>;
+    return this as unknown as Either<ReturnType<typeof fn>, R>
   }
 
   right<T>(fn: (value: R) => T): Either<L, T> {
-    return new Right<L, T>(fn(this.val));
+    return new Right<L, T>(fn(this.val))
   }
 
   isLeft() {
-    return false;
+    return false
   }
 
   isRight() {
-    return true;
+    return true
   }
 
   unwrap() {
-    return this.val;
+    return this.val
   }
 }
 

--- a/src/Either/Right.ts
+++ b/src/Either/Right.ts
@@ -1,0 +1,51 @@
+import { Either } from './Either';
+
+/**
+ * Represents the right side of an Either type.
+ * @class Right
+ * @implements {Either}
+ * @template L - The type of the left side.
+ * @template R - The type of the right side.
+ */
+export class Right<L, R> implements Either<L, R> {
+  /**
+   * Private constructor to create an instance of Right.
+   * @private
+   * @constructor
+   * @param {R} val - The value on the right side.
+   */
+  private constructor(private val: R) {}
+
+  /**
+   * Static method to create an instance of Right.
+   * @param {R} value - The value on the right side.
+   * @returns {Right} An instance of Right.
+   */
+  static create<L, R>(value: R) {
+    return new Right<L, R>(value);
+  }
+
+  left<T>(fn: (value: L) => T): Either<T, R> {
+    return this as unknown as Either<T, R>;
+  }
+
+  right<T>(fn: (value: R) => T): Either<L, T> {
+    return new Right<L, T>(fn(this.val));
+  }
+
+  isLeft() {
+    return false;
+  }
+
+  isRight() {
+    return true;
+  }
+
+  unwrap() {
+    return this.val;
+  }
+}
+
+export function right<L, R>(value: R): Either<L, R> {
+  return Right.create<L, R>(value)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
 export * from './Maybe/Maybe'
 export * from './Lazy/Lazy'
 export * from './History/History'
+export * from './Either/Either'
+export * from './Either/Left'
+export * from './Either/Right'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    coverage: {
+      all: false,
+      provider: 'v8',
+    },
+  },
+})


### PR DESCRIPTION
# Description

Add `Either` implementation 

### Usage

`Either` functor represents a type that can be either of type L or R, providing a mechanism for branching based on success or failure.

```ts
import { Either, left, right } from '@ortense/functors'

const divide = (
  numerator: number,
  denominator: number,
): Either<Error, number> => {
  if (Number.isNaN(numerator)) {
    return left(new Error('Numerator is not a number.'))
  }
  if (Number.isNaN(denominator)) {
    return left(new Error('Denominator is not a number.'))
  }

  if (denominator === 0) {
    return left(new Error('Division by zero is not posible.'))
  }

  return right(numerator / denominator)
}

const numerator = Number(document.querySelector('input#numerator').value)
const denominator = Number(document.querySelector('input#denominator').value)
const display = document.querySelector('div#display-result')

divide(numerator, denominator)
  .right(result => {
    display.textContent = `${numerator} / ${denominator} = ${result}`
  })
  .left(error => {
    display.textContent = error.message
  })
```