### PR TITLE
feat: add flat and flatMap methods to Maybe functor

### DIFF
--- a/.changeset/chilled-ads-talk.md
+++ b/.changeset/chilled-ads-talk.md
@@ -1,0 +1,5 @@
+---
+"@ortense/functors": minor
+---
+
+Add methods flat and flatMap to Maybe

--- a/src/Maybe/Maybe.spec.ts
+++ b/src/Maybe/Maybe.spec.ts
@@ -61,5 +61,35 @@ describe('Maybe', () => {
         expect(maybeVal.unwrap()).toBe(value)
       })
     })
+
+    describe('.flat', () => {
+      it('should flatten a Maybe with nested Maybe', () => {
+        const nestedMaybe = maybe(maybe('nested value'))
+        const flattenedMaybe = nestedMaybe.flat()
+        expect(flattenedMaybe.unwrap()).toBe('nested value')
+      })
+
+      it('should not modify a Maybe with non-nested value', () => {
+        const maybeStr = maybe('non-nested value')
+        const flattenedMaybe = maybeStr.flat()
+        expect(flattenedMaybe.unwrap()).toBe('non-nested value')
+      })
+    })
+
+    describe('.flatMap', () => {
+      it('should apply mapping function and flatten the result', () => {
+        const maybeVal = maybe('value')
+        const fn = (val: string) => maybe(val.toUpperCase())
+        const resultMaybe = maybeVal.flatMap(fn)
+        expect(resultMaybe.unwrap()).toBe('VALUE')
+      })
+
+      it('should apply function to nested value', () => {
+        const maybeStr = maybe(maybe('nested value'))
+        const fn = (val: string) => val.toUpperCase()
+        const resultMaybe = maybeStr.flatMap(fn)
+        expect(resultMaybe.unwrap()).toBe('NESTED VALUE')
+      })
+    })
   })
 })

--- a/src/Maybe/Maybe.ts
+++ b/src/Maybe/Maybe.ts
@@ -1,4 +1,11 @@
 /**
+ * Obtains the wrapped type of a Maybe instance, if it exists.
+ * otherwise, returns the original type.
+ * @template T - The type of the Maybe instance.
+ */
+export type MaybeValueType<T> = T extends Maybe<infer U> ? U : T
+
+/**
  * Represents a container that may or may not contain a value of type T.
  * @class Maybe
  * @template T - The type of the value.
@@ -68,6 +75,29 @@ export class Maybe<T> {
    */
   unwrap(): T | null | undefined {
     return this.value
+  }
+
+  /**
+   * Flattens a Maybe instance by removing one level of nesting, if applicable.
+   * If the internal value is a Maybe instance, returns that instance directly;
+   * otherwise, returns the original Maybe instance.
+   * @returns {Maybe<MaybeValueType<T>>} A new Maybe instance with one level of nesting removed.
+   */
+  flat(): Maybe<MaybeValueType<T>> {
+    if (this.value instanceof Maybe) {
+      return this.value
+    }
+    return this as unknown as Maybe<MaybeValueType<T>>
+  }
+
+  /**
+   * Maps the wrapped value of Maybe using a provided function and then flattens the result.
+   * @template R - The type of the result after applying the function.
+   * @param {function(MaybeValueType<T>): R} fn - The mapping function to apply to the internal value.
+   * @returns {Maybe<R>} A new Maybe instance containing the result of applying the function.
+   */
+  flatMap<R>(fn: (value: MaybeValueType<T>) => R): Maybe<MaybeValueType<R>> {
+    return this.flat().map(fn).flat()
   }
 }
 


### PR DESCRIPTION
# description

Add flat and flatMap methods to Maybe functor

## .flat

A method to removing one level of nesting, if applicable.

```ts
const data = maybe(maybe('data')) //? Maybe<Maybe<string>>

const flatted = data.flat() //? Maybe<string>

const nonNestedFlatted = flatted.flat() //? Maybe<string> 
```

## .flatMap

Useful to combine functions that returns Maybe
```ts
const divide = (denominator: number) =>
  (numerator: number) => denominator === 0
    ? maybe(null) : maybe(numerator/denominator)

const getFromLocalStorage = (key: string) =>
  maybe(localStorage.getItem(key))
```

When a function returns a Maybe
```ts
getFromLocalStorage('count') //? Maybe<string>
  .map(Number) //? Maybe<number>
  .map(divide(2)) //? Maybe<Maybe<number>>

getFromLocalStorage('count') //? Maybe<string>
  .map(Number) //? Maybe<number>
  .flatMap(divide(2)) //? Maybe<number>
```

When needs to map a nested Maybe
```ts
getFromLocalStorage('count') //? Maybe<string>
  .map(Number) //? Maybe<number>
  .map(divide(2)) //? Maybe<Maybe<number>>
  .flatMap(value => value + 1) // Maybe<number>
```